### PR TITLE
added header in data.txt

### DIFF
--- a/src/python/vasp_mdstat.py
+++ b/src/python/vasp_mdstat.py
@@ -60,4 +60,4 @@ if __name__ == "__main__":
 
     # Save data
     data = np.c_[results["T"], results["PE"], results["KE"]]
-    np.savetxt("data.txt", data)
+    np.savetxt("data.txt", data, header="T      PE      KE")


### PR DESCRIPTION
- `vasp_mdstat` produces `data.txt`, but it doesn't contain column names
- Add `header` argument in `np.savetxt`