### PR TITLE
Update gotojob.sh

### DIFF
--- a/src/bash/gotojob.sh
+++ b/src/bash/gotojob.sh
@@ -6,6 +6,22 @@ function gotojob {
         echo "usage: $FUNCNAME [SLURM_JOBID]"
         return
     fi
+    
+    # Store the output of scontrol in a variable
+    scontrol_output=$(scontrol show job $1 2>&1)
+    
+    # Check if there was an error
+    if [[ $scontrol_output == *"error"* ]]; then
+        echo "Error: Invalid job ID or job not found"
+        return 1
+    fi
     workdir=$(scontrol show job $1 | grep Dir | awk -F '=' '{print $2}')
-    cd $workdir
+    
+    # Change directory only if workdir is not empty
+    if [[ -n "$workdir" ]]; then
+        cd "$workdir"
+    else
+        echo "Error: Could not determine working directory for job $1"
+        return 1
+    fi
 }


### PR DESCRIPTION
If an invalid [SLURM ID] is entered, it returns an error and stays in "current" directory instead of going to "home" directory.